### PR TITLE
Fix link to cloning repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Quickstart
 ```bash
-git clone git@github.com/flynn-ssl-cert.git
+git clone git@github.com/afgallo/flynn-ssl-cert.git
 cd flynn-ssl-cert
 chmod a+x ./gen-cert.sh
 ```


### PR DESCRIPTION
The git url in the README is incorrect and doens't include the user. This PR repairs the url